### PR TITLE
Fixing openssl version to 1.1

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,9 +13,8 @@ jobs:
         container:
           - ubuntu:latest
         php-version:
-          - 7.4.14
-          - 8.0.0
-          - latest
+          - 7.4.25
+          - 8.0.8
 
     env:
       DEBIAN_FRONTEND: noninteractive
@@ -41,15 +40,14 @@ jobs:
         os:
           - macos-latest
         php-version:
-          - 7.4.14
-          - 8.0.0
-          - latest
+          - 7.4.25
+          - 8.0.8
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Install packages
-        run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip openssl@1.1 pkg-config re2c zlib
+        run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip openssl@1.1 pcre pkg-config re2c zlib
 
       - name: Install conflicting packages
         run: brew install openssl@3  

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Install packages
-        run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip openssl@1.1 pcre pkg-config re2c zlib
+        run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip openssl@1.1 pcre postgres pkg-config re2c zlib
 
       - name: Install conflicting packages
         run: brew install openssl@3  

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,6 +13,7 @@ jobs:
         container:
           - ubuntu:latest
         php-version:
+          - 7.4.22
           - 7.4.25
           - 8.0.8
 
@@ -41,6 +42,7 @@ jobs:
           - macos-11
           - macos-10.15
         php-version:
+          - 7.4.22
           - 7.4.25
           - 8.0.8
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,6 +3,8 @@ name: Main workflow
 on:
   pull_request:
   push:
+    branches:
+      - master
   schedule:
     - cron: 0 0 * * 5
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,11 +34,12 @@ jobs:
           command: php --version
           version: ${{ matrix.php-version }}
 
-  plugin-test-vm:
+  plugin-test-macos:
     strategy:
       matrix:
         os:
-          - macos-latest
+          - macos-11
+          - macos-10.15
         php-version:
           - 7.4.25
           - 8.0.8
@@ -50,7 +51,7 @@ jobs:
         run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip openssl@1.1 pcre postgres pkg-config re2c zlib
 
       - name: Install conflicting packages
-        run: brew install openssl@3  
+        run: brew install openssl@3
 
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -49,7 +49,10 @@ jobs:
 
     steps:
       - name: Install packages
-        run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip pkg-config re2c zlib
+        run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip openssl@1.1 pkg-config re2c zlib
+
+      - name: Install conflicting packages
+        run: brew install openssl@3  
 
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v1

--- a/bin/install
+++ b/bin/install
@@ -214,6 +214,7 @@ os_based_configure_options() {
     local readline_path=$(homebrew_package_path readline)
     local webp_path=$(homebrew_package_path webp)
     local zlib_path=$(homebrew_package_path zlib)
+    local pcre_path=$(homebrew_package_path pcre)
 
     # optional
     # if these packages exist they are included in the php compilation
@@ -288,6 +289,12 @@ os_based_configure_options() {
       configure_options="$configure_options --with-zlib-dir=$zlib_path"
     else
       export ASDF_PKG_MISSING="$ASDF_PKG_MISSING zlib"
+    fi
+
+    if [ -n "$pcre_path" ]; then
+      configure_options="$configure_options --with-external-pcre"
+    else
+      export ASDF_PKG_MISSING="$ASDF_PKG_MISSING pcre"
     fi
 
     if [ -n "$libzip_path" ]; then

--- a/bin/install
+++ b/bin/install
@@ -165,12 +165,6 @@ construct_configure_options() {
     configure_options="$configure_options --with-pear"
   fi
 
-  if [ "${PHP_WITHOUT_PDO_PGSQL:-no}" != "no" ]; then
-    configure_options="$configure_options"
-  else
-    configure_options="$configure_options --with-pdo-pgsql"
-  fi
-
   echo "$configure_options"
 }
 
@@ -215,6 +209,7 @@ os_based_configure_options() {
     local webp_path=$(homebrew_package_path webp)
     local zlib_path=$(homebrew_package_path zlib)
     local pcre_path=$(homebrew_package_path pcre)
+    local postgres_path=$(homebrew_package_path postgres)
 
     # optional
     # if these packages exist they are included in the php compilation
@@ -297,6 +292,16 @@ os_based_configure_options() {
       export ASDF_PKG_MISSING="$ASDF_PKG_MISSING pcre"
     fi
 
+    if [ "${PHP_WITHOUT_PDO_PGSQL:-no}" != "no" ]; then
+      configure_options="$configure_options"
+    else
+      if [ -n "$postgres_path" ]; then
+        configure_options="$configure_options --with-pdo-pgsql=$postgres_path"
+      else
+        export ASDF_PKG_MISSING="$ASDF_PKG_MISSING postgres"
+      fi
+    fi
+
     if [ -n "$libzip_path" ]; then
       configure_options="$configure_options --with-libzip=$libzip_path"
     else
@@ -341,6 +346,12 @@ os_based_configure_options() {
       export ASDF_PKG_MISSING="$ASDF_PKG_MISSING libpng"
     else
       configure_options="$configure_options --with-png-dir=$libpng_path --with-png"
+    fi
+
+    if [ "${PHP_WITHOUT_PDO_PGSQL:-no}" != "no" ]; then
+      configure_options="$configure_options"
+    else
+      configure_options="$configure_options --with-pdo-pgsql"
     fi
   fi
 

--- a/bin/install
+++ b/bin/install
@@ -27,7 +27,7 @@ install_php() {
     local krb5_path=$(homebrew_package_path krb5)
     local libedit_path=$(homebrew_package_path libedit)
     local libxml2_path=$(homebrew_package_path libxml2)
-    local openssl_path=$(homebrew_package_path openssl)
+    local openssl_path=$(homebrew_package_path openssl@1.1)
 
     if [ -n "${bison_path}" ]; then
       export "PATH=${bison_path}/bin:${PATH}"
@@ -200,7 +200,7 @@ os_based_configure_options() {
     local webp_path=$(homebrew_package_path webp)
     local jpeg_path=$(homebrew_package_path jpeg)
     local libpng_path=$(homebrew_package_path libpng)
-    local openssl_path=$(homebrew_package_path openssl)
+    local openssl_path=$(homebrew_package_path openssl@1.1)
     local libxml2_path=$(homebrew_package_path libxml2)
     local zlib_path=$(homebrew_package_path zlib)
     local readline_path=$(homebrew_package_path readline)


### PR DESCRIPTION
This PR solves an issue where we couldn't build php on machines where openssl was upgraded to V3, for this change to work on your machine you need to make sure you also have openssl@1.1 installed in your system.
This PR also addresses the issue of compiling on M1, but only for 7.4.25 and 8.0.8.