### PR TITLE
Start Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip openssl@3 pcre pkg-config re2c zlib
 
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v1
+        uses: asdf-vm/actions/plugin-test@v2
         with:
           command: php --version
           version: ${{ matrix.php-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Install packages
+      - name: Install brews
         run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip openssl@3 pcre pkg-config re2c zlib
 
-      - name: asdf_plugin_test
+      - name: Test install
         uses: asdf-vm/actions/plugin-test@v2
         with:
           command: php --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
         php-version:
           - 8.0.30
           - 8.1.22
-          - 8.2.9
 
     env:
       DEBIAN_FRONTEND: noninteractive
@@ -46,7 +45,6 @@ jobs:
         php-version:
           - 8.0.30
           - 8.1.22
-          - 8.2.9
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
   schedule:
+    # Every Friday at 00:00
     - cron: 0 0 * * 5
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,10 +50,7 @@ jobs:
 
     steps:
       - name: Install packages
-        run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip openssl@1.1 pcre pkg-config re2c zlib
-
-      - name: Install conflicting packages
-        run: brew install openssl@3
+        run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip openssl@3 pcre pkg-config re2c zlib
 
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         os:
           - macos-13
-          - macos-12
         php-version:
           - 8.0.30
           - 8.1.22

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Main workflow
+name: Test
 
 on:
   pull_request:
@@ -62,16 +62,3 @@ jobs:
         with:
           command: php --version
           version: ${{ matrix.php-version }}
-
-  format:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Install shfmt
-        run: brew install shfmt
-
-      - name: Run shfmt
-        run: make fmt-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,11 +38,14 @@ jobs:
           libpng
           libxml2
           libzip
-          openssl@3
+          openssl@1.1
           pcre
           pkg-config
           re2c
           zlib
+
+      - name: Install conflicts
+        run: brew install openssl@3
 
       - name: Test install
         uses: asdf-vm/actions/plugin-test@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,27 @@ jobs:
 
     steps:
       - name: Install brews
-        run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip openssl@3 pcre pkg-config re2c zlib
+        run: >-
+          brew install
+          autoconf
+          automake
+          bison
+          freetype
+          gd
+          gettext
+          icu4c
+          krb5
+          libedit
+          libiconv
+          libjpeg
+          libpng
+          libxml2
+          libzip
+          openssl@3
+          pcre
+          pkg-config
+          re2c
+          zlib
 
       - name: Test install
         uses: asdf-vm/actions/plugin-test@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,33 +9,6 @@ on:
     - cron: 0 0 * * 5
 
 jobs:
-  plugin-test-docker:
-    strategy:
-      matrix:
-        container:
-          - ubuntu:latest
-        php-version:
-          - 8.0.30
-          - 8.1.22
-
-    env:
-      DEBIAN_FRONTEND: noninteractive
-
-    container:
-      image: ${{ matrix.container }}
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Install packages
-        run: apt-get update && apt-get install -y autoconf bison build-essential curl gettext git libgd-dev libcurl4-openssl-dev libedit-dev libicu-dev libjpeg-dev libmysqlclient-dev libonig-dev libpng-dev libpq-dev libreadline-dev libsqlite3-dev libssl-dev libxml2-dev libzip-dev openssl pkg-config re2c zlib1g-dev
-
-      - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v1
-        with:
-          command: php --version
-          version: ${{ matrix.php-version }}
-
   plugin-test-macos:
     strategy:
       matrix:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,10 +15,9 @@ jobs:
         container:
           - ubuntu:latest
         php-version:
-          - 7.4.22
-          - 7.4.25
-          - 8.0.8
-          - 8.1.0
+          - 8.0.30
+          - 8.1.22
+          - 8.2.9
 
     env:
       DEBIAN_FRONTEND: noninteractive
@@ -42,13 +41,12 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-11
-          - macos-10.15
+          - macos-13
+          - macos-12
         php-version:
-          - 7.4.22
-          - 7.4.25
-          - 8.0.8
-          - 8.1.0
+          - 8.0.30
+          - 8.1.22
+          - 8.2.9
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Install packages
-        run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip openssl@1.1 pcre postgres pkg-config re2c zlib
+        run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip openssl@1.1 pcre pkg-config re2c zlib
 
       - name: Install conflicting packages
         run: brew install openssl@3

--- a/bin/install
+++ b/bin/install
@@ -28,7 +28,7 @@ install_php() {
     local krb5_path=$(homebrew_package_path krb5)
     local libedit_path=$(homebrew_package_path libedit)
     local libxml2_path=$(homebrew_package_path libxml2)
-    local openssl_path=$(homebrew_package_path openssl@1.1)
+    local openssl_path=$(homebrew_package_path openssl@3)
 
     if [ -n "$bison_path" ]; then
       export "PATH=${bison_path}/bin:${PATH}"

--- a/bin/install
+++ b/bin/install
@@ -209,7 +209,7 @@ os_based_configure_options() {
     local webp_path=$(homebrew_package_path webp)
     local zlib_path=$(homebrew_package_path zlib)
     local pcre_path=$(homebrew_package_path pcre)
-    local postgres_path=$(homebrew_package_path postgres)
+    local postgres_path=$(homebrew_package_path libpq)
 
     # optional
     # if these packages exist they are included in the php compilation

--- a/bin/install
+++ b/bin/install
@@ -28,7 +28,7 @@ install_php() {
     local krb5_path=$(homebrew_package_path krb5)
     local libedit_path=$(homebrew_package_path libedit)
     local libxml2_path=$(homebrew_package_path libxml2)
-    local openssl_path=$(homebrew_package_path openssl@3)
+    local openssl_path=$(homebrew_package_path openssl@1.1)
 
     if [ -n "$bison_path" ]; then
       export "PATH=${bison_path}/bin:${PATH}"

--- a/bin/install
+++ b/bin/install
@@ -331,31 +331,12 @@ os_based_configure_options() {
     else
       export ASDF_PKG_MISSING="$ASDF_PKG_MISSING libiconv"
     fi
+
+    echo $configure_options
   else
-    local jpeg_path=$(locate libjpeg.so | awk '{ print length(), $0 | "sort -n" }' | cut -d" " -f2- | head -n 1)
-    local libpng_path=$(locate libpng.so | awk '{ print length(), $0 | "sort -n" }' | cut -d" " -f2- | head -n 1)
-    configure_options="--with-openssl --with-curl --with-zlib --with-readline --with-gettext"
-
-    if [ "$jpeg_path" = "" ]; then
-      export ASDF_PKG_MISSING="$ASDF_PKG_MISSING jpeg"
-    else
-      configure_options="$configure_options --with-jpeg-dir=$jpeg_path --with-jpeg"
-    fi
-
-    if [ "$libpng_path" = "" ]; then
-      export ASDF_PKG_MISSING="$ASDF_PKG_MISSING libpng"
-    else
-      configure_options="$configure_options --with-png-dir=$libpng_path --with-png"
-    fi
-
-    if [ "${PHP_WITHOUT_PDO_PGSQL:-no}" != "no" ]; then
-      configure_options="$configure_options"
-    else
-      configure_options="$configure_options --with-pdo-pgsql"
-    fi
+    echo "Unsupported Operating System: ${operation_system}" 1>&2
+    return 1
   fi
-
-  echo $configure_options
 }
 
 download_source() {


### PR DESCRIPTION
Summary:

* Remove support for non-MacOS installs. The ubuntu tests were failing, so they got the axe. Skillshare only uses MacOS.
* Update the supported MacOS versions to 13
* Test against PHP 8.0 and 8.1
* Remove the broken `lint` workflow. Replacement will happen in a separate PR.
* Fix a breakage caused by `brew` dropping the `postgres` brew